### PR TITLE
feat: Enable prettier by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To create a new project, run the following command and follow the instructions:
 ```sh
 $> mkdir my-monorepo
 $> cd my-monorepo
+$> cat "@vincenthsh:registry=https://npm.pkg.github.com/" >> ~/.npmrc
 $> npx projen new --from @vincenthsh/projen-turborepo --projenrc-ts
 🤖 Synthesizing project...
 ...

--- a/test/__snapshots__/synth.test.ts.snap
+++ b/test/__snapshots__/synth.test.ts.snap
@@ -200,13 +200,13 @@ Object {
     "name": "upgrade",
     "steps": Array [
       Object {
-        "exec": "pnpm dlx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@vincenthsh/projen-turborepo,eslint-import-resolver-typescript,eslint-plugin-import,projen,turbo,typescript",
+        "exec": "pnpm dlx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@vincenthsh/projen-turborepo,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,prettier,projen,turbo,typescript",
       },
       Object {
         "exec": "pnpm i --no-frozen-lockfile",
       },
       Object {
-        "exec": "pnpm update @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser @vincenthsh/projen-turborepo constructs eslint-import-resolver-typescript eslint-plugin-import eslint projen standard-version turbo typescript",
+        "exec": "pnpm update @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser @vincenthsh/projen-turborepo constructs eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint prettier projen standard-version turbo typescript",
       },
       Object {
         "exec": "npx projen",

--- a/test/synth.test.ts
+++ b/test/synth.test.ts
@@ -42,6 +42,17 @@ describe("TurborepoProject", () => {
     expect(synth["package.json"].private).toBe(true);
   });
 
+  it("should force pnpm node-linker to hoist for bundled deps", () => {
+    expect.assertions(1);
+
+    const project = createProject({
+      bundledDeps: ["dotalias"],
+    });
+    const synth = synthProjectSnapshot(project);
+
+    expect(synth[".npmrc"]).toContain("node-linker=hoisted");
+  });
+
   it("should add turbo runs commands", () => {
     expect.assertions(1);
 


### PR DESCRIPTION
- Enable prettier by default
- Set node and pnpm versions in package.engines
- Set pnpm node-linker automatically if bundleDeps exist
